### PR TITLE
Env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,12 @@ Likewise, the name of the file defaults to `config` but it can be changed via:
 Within this file the `default` profile is the one that will be used, unless
 instructed otherwise via:
 ```sbtshell
-> set Global/apiBuilderProfile := "other"
+> set Global/apiBuilderProfile := Some("other")
 ```
+or with the `APIBUILDER_PROFILE` environment variable.
+
+Otherwise, the token can be specified with the `APIBUILDER_TOKEN` environment variable.
+
 Finally, the ApiBuilder files are expected to be found hitting the endpoint
 `https://api.apibuilder.io`. If that is not the case (e.g. you host an internal
 repository), just set the plugin to fetch from a different endpoint:

--- a/src/main/scala/apibuilder/sbt/ApiBuilderPlugin.scala
+++ b/src/main/scala/apibuilder/sbt/ApiBuilderPlugin.scala
@@ -19,7 +19,7 @@ object ApiBuilderPlugin extends AutoPlugin {
       settingKey[File]("The directory where to find the global ApiBuilder config file (default: ~/.apibuilder)")
     val apiBuilderGlobalConfigFilename =
       settingKey[String]("The name of the global ApiBuilder config file (default: config)")
-    val apiBuilderProfile = settingKey[Option[String]]("The profile name to use (default: default)")
+    val apiBuilderProfile = settingKey[Option[String]]("The profile name to use (default when none specified: default)")
     val apiBuilderUrl     = settingKey[URL]("The Api Builder URL to use (default: https://api.apibuilder.io)")
 
     val apiBuilderCLIConfigDirectory =
@@ -69,7 +69,7 @@ object ApiBuilderPlugin extends AutoPlugin {
       val localCLIConfigFile = apiBuilderCLIConfigDirectory.value / apiBuilderCLIConfigFilename.value
       val basePath           = sourceManaged.value.toPath
 
-      val token: Option[String] = Properties.envOrNone("APIBUILDER_PROFILE")
+      val token: Option[String] = Properties.envOrNone("APIBUILDER_TOKEN")
         .orElse {
           logFileContents(globalConfigFile)(GlobalConfig.load)
             .toOption

--- a/src/main/scala/apibuilder/sbt/ApiBuilderPlugin.scala
+++ b/src/main/scala/apibuilder/sbt/ApiBuilderPlugin.scala
@@ -8,6 +8,7 @@ import sbt.{Def, _}
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
+import scala.util.Properties
 
 object ApiBuilderPlugin extends AutoPlugin {
 
@@ -18,7 +19,7 @@ object ApiBuilderPlugin extends AutoPlugin {
       settingKey[File]("The directory where to find the global ApiBuilder config file (default: ~/.apibuilder)")
     val apiBuilderGlobalConfigFilename =
       settingKey[String]("The name of the global ApiBuilder config file (default: config)")
-    val apiBuilderProfile = settingKey[String]("The profile name to use (default: default)")
+    val apiBuilderProfile = settingKey[Option[String]]("The profile name to use (default: default)")
     val apiBuilderUrl     = settingKey[URL]("The Api Builder URL to use (default: https://api.apibuilder.io)")
 
     val apiBuilderCLIConfigDirectory =
@@ -35,7 +36,7 @@ object ApiBuilderPlugin extends AutoPlugin {
   override def globalSettings: Seq[Def.Setting[_]] = Seq(
     apiBuilderGlobalConfigDirectory := Path.userHome / ".apibuilder",
     apiBuilderGlobalConfigFilename := "config",
-    apiBuilderProfile := "default",
+    apiBuilderProfile := None,
     apiBuilderUrl := url("https://api.apibuilder.io")
   )
 
@@ -63,17 +64,24 @@ object ApiBuilderPlugin extends AutoPlugin {
       def basicAuth(token: String): String = s"Basic ${B64.encodeToString(s"$token:".getBytes(UTF_8))}"
 
       val globalConfigFile   = apiBuilderGlobalConfigDirectory.value / apiBuilderGlobalConfigFilename.value
-      val profile            = apiBuilderProfile.value
+      val profile            = apiBuilderProfile.value.getOrElse(Properties.envOrElse("APIBUILDER_PROFILE", "default" ))
       val url                = apiBuilderUrl.value
       val localCLIConfigFile = apiBuilderCLIConfigDirectory.value / apiBuilderCLIConfigFilename.value
       val basePath           = sourceManaged.value.toPath
 
-      val clientOrError = logFileContents(globalConfigFile)(GlobalConfig.load).flatMap { config =>
-        config.profiles.get(profile).map(_.token) match {
-          case None        => Left(new RuntimeException(s"missing token for profile '$profile'"))
-          case Some(token) => Right(new ApiBuilderClient(log, url, basicAuth(token)))
+      val token: Option[String] = Properties.envOrNone("APIBUILDER_PROFILE")
+        .orElse {
+          logFileContents(globalConfigFile)(GlobalConfig.load)
+            .toOption
+            .flatMap(_.profiles.get(profile))
+            .map(_.token)
         }
+
+      val clientOrError = token match {
+        case None        => Left(new RuntimeException(s"missing token"))
+        case Some(token) => Right(new ApiBuilderClient(log, url, basicAuth(token)))
       }
+
       val requestsOrError = logFileContents(localCLIConfigFile)(CLIConfig.load).map(ApiBuilderRequests.fromCLIConfig)
 
       val eventualResponses = (clientOrError, requestsOrError) match {


### PR DESCRIPTION
https://github.com/sirocchj/sbt-api-builder/issues/4

Allow environment variables like [apibuilder-cli](https://github.com/apicollective/apibuilder-cli#environment-variables). The main difference is the `PROFILE` variable is named `APIBUILDER_PROFILE` to avoid the very generic name.