### PR TITLE
Fixes #15: Allow for optional file.dir property in apibuilder response

### DIFF
--- a/src/main/scala/apibuilder/sbt/Code.scala
+++ b/src/main/scala/apibuilder/sbt/Code.scala
@@ -18,8 +18,8 @@ object Code extends BaseDecoders {
   implicit final val codeFileDecoder: Decoder[CodeFile] = Decoder.instance { c =>
     for {
       name     <- c.downField("name").as[Path]
-      dir      <- c.downField("dir").as[Path]
+      dir      <- c.downField("dir").as[Option[Path]]
       contents <- c.downField("contents").as[String]
-    } yield CodeFile(name, dir, contents)
+    } yield CodeFile(name, dir.getOrElse(Paths.get("")), contents)
   }
 }


### PR DESCRIPTION
This property is optional according to the apibuilder spec:
https://app.apibuilder.io/apicollective/apibuilder-generator/latest#model-file